### PR TITLE
fix historical data key

### DIFF
--- a/crawler/main.js
+++ b/crawler/main.js
@@ -112,7 +112,7 @@ function startProcessingJobs() {
   // TODO: Configurable number of urls processing concurrently
   queue.process('parse site', 50, (job, done) => {
     urlJobProcessor.processUrlJob(job.data).then((result) => {
-      return dataStore.updateWithCurrentCrawlResult(job.data, result).then(() => {
+      return dataStore.updateWithCurrentCrawlResult(job.data.title, result).then(() => {
         done(null, result);
       });
     }).catch((err) => {

--- a/crawler/urlJobProcessor.js
+++ b/crawler/urlJobProcessor.js
@@ -8,7 +8,6 @@ function configure() {
 }
 
 function processUrlJob(data) {
-  console.log(data);
   const urlStr = data.title;
   console.log(`[${Date.now()}] start - ${urlStr}`);
 


### PR DESCRIPTION
To fix view of `kue` status I've changed `job.data` from simple url to an object with `title` parameter.
It needs to be changed in every place where it understands it as an url.
